### PR TITLE
Add support for onType Selectize Event

### DIFF
--- a/addon/components/ui-selectize.js
+++ b/addon/components/ui-selectize.js
@@ -166,6 +166,7 @@ export default Ember.Component.extend(MoodManager,SizeManager,StyleManager,ApiSu
 		config.onDropdownClose = Ember.$.proxy(this._onDropdownClose, this);
 		config.onItemAdd = Ember.$.proxy(this._onItemAdd, this);
 		config.onItemRemove = Ember.$.proxy(this._onItemRemove, this);
+		config.onType = Ember.$.proxy(this._onType, this);
     // The "create" callback is handled somewhat differently
     if(typeOf(config.create) === 'function') {
       config.create = Ember.$.proxy(config.create, this);

--- a/addon/mixins/api-surface.js
+++ b/addon/mixins/api-surface.js
@@ -136,6 +136,9 @@ var ApiSurface = Ember.Mixin.create({
     _onItemRemove:function(value) {
       this.sendAction('onItemRemove', value);
     },
+    _onType:function(value) {
+      this.sendAction('onType', value);
+    },
 
     selected: false,
     selectize: null,

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -408,5 +408,6 @@
     <li>onDropdownClose</li>
     <li>onItemAdd</li>
     <li>onItemRemove</li>
+    <li>onType</li>
   </ul>
 </p>


### PR DESCRIPTION
onType event is fired as a text is entered. It useful when working with
Selectize fields that hit a large server side data set so that it can be
filtered as you type.
